### PR TITLE
Add golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,103 @@
+linters-settings:
+  govet:
+    check-shadowing: true
+  golint:
+    min-confidence: 0
+  gocyclo:
+    min-complexity: 10
+  maligned:
+    suggest-new: true
+  dupl:
+    threshold: 100
+  goconst:
+    min-len: 2
+    min-occurrences: 2
+  depguard:
+  misspell:
+    locale: US
+  lll:
+    line-length: 140
+  goimports:
+    local-prefixes: github.com/mitsuhitofujita/go-aws-s3
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - experimental
+      - opinionated
+      - performance
+      - style
+#    disabled-checks:
+#      - wrapperFunc
+#      - dupImport # https://github.com/go-critic/go-critic/issues/845
+#      - ifElseChain
+#      - octalLiteral
+  funlen:
+    lines: 100
+    statements: 50
+
+linters:
+  # please, do not use `enable-all`: it's deprecated and will be removed soon.
+  # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
+  disable-all: true
+  enable:
+    - bodyclose
+    - deadcode
+    - depguard
+    - dogsled
+    - dupl
+    - errcheck
+    - funlen
+    - gochecknoinits
+    - goconst
+    - gocritic
+    - gocyclo
+    - gofmt
+    - goimports
+    - golint
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - interfacer
+    - lll
+    - misspell
+    - nakedret
+    - scopelint
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - whitespace
+
+  # don't enable:
+  # - gochecknoglobals
+  # - gocognit
+  # - godox
+  # - maligned
+  # - prealloc
+
+# run:
+#   skip-dirs:
+#     - test/testdata_etc
+#   skip-files:
+#     - internal/cache/.*_test.go
+
+# issues:
+#   exclude-rules:
+#     - path: internal/(cache|renameio)/
+#       linters:
+#         - lll
+#         - gochecknoinits
+#         - gocyclo
+#         - funlen
+
+# golangci.com configuration
+# https://github.com/golangci/golangci/wiki/Configuration
+service:
+  golangci-lint-version: 1.20.x # use the fixed version to not introduce new linters unexpectedly
+  prepare:
+    - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.13
 require (
 	github.com/aws/aws-sdk-go v1.25.16
 	golang.org/x/net v0.0.0-20191101175033-0deb6923b6d9 // indirect
+	golang.org/x/tools v0.0.0-20191101200257-8dbcdeb83d3f // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,13 @@ github.com/aws/aws-sdk-go v1.25.16/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpi
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191101175033-0deb6923b6d9 h1:DPz9iiH3YoKiKhX/ijjoZvT0VFwK2c6CWYWQ7Zyr8TU=
 golang.org/x/net v0.0.0-20191101175033-0deb6923b6d9/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/tools v0.0.0-20191101200257-8dbcdeb83d3f h1:+QO45yvqhfD79HVNFPAgvstYLFye8zA+rd0mHFsGV9s=
+golang.org/x/tools v0.0.0-20191101200257-8dbcdeb83d3f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/s3/s3_test.go
+++ b/s3/s3_test.go
@@ -2,9 +2,10 @@ package s3
 
 import (
 	"errors"
+	"testing"
+
 	client "github.com/aws/aws-sdk-go/service/s3"
 	manager "github.com/aws/aws-sdk-go/service/s3/s3manager"
-	"testing"
 )
 
 type HeadGetterTest struct {
@@ -50,7 +51,6 @@ func (hmt *HashMakerTest) makeSinglePartFromFile(filePath string) (hash string, 
 	return
 }
 
-
 type UploaderTest struct {
 	Values           []UploaderTestValue
 	CurrentPosition  int
@@ -69,9 +69,9 @@ func (ut *UploaderTest) upload(s3 *S3, filePath, s3Path string) (out *manager.Up
 	return
 }
 
+//nolint:funlen
 func TestUpload(t *testing.T) {
-
-	eTag := "  \"1234567890\"  "
+	eTag := "  \"1234567890\"  " //nolint:goconst
 	contentLength := int64(123)
 
 	cases := []struct {
@@ -219,7 +219,7 @@ func TestUpload(t *testing.T) {
 	}
 	for _, c := range cases {
 		s3, err := New(&Config{
-			Id:         "ID",
+			ID:         "ID",
 			Uploader:   &c.uploader,
 			HeadGetter: &c.headGetter,
 			HashMaker:  &c.hashMaker,
@@ -259,7 +259,6 @@ func TestUpload(t *testing.T) {
 	}
 }
 
-
 type DownloaderTest struct {
 	Values           []DownloaderTestValue
 	CurrentPosition  int
@@ -278,9 +277,9 @@ func (dt *DownloaderTest) download(s3 *S3, filePath, s3Path string) (out int64, 
 	return
 }
 
+//nolint:funlen
 func TestDownload(t *testing.T) {
-
-	eTag := "  \"1234567890\"  "
+	eTag := "  \"1234567890\"  " //nolint:goconst
 	contentLength := int64(123)
 
 	cases := []struct {
@@ -428,8 +427,8 @@ func TestDownload(t *testing.T) {
 	}
 	for _, c := range cases {
 		s3, err := New(&Config{
-			Id:         "ID",
-			Downloader:   &c.downloader,
+			ID:         "ID",
+			Downloader: &c.downloader,
 			HeadGetter: &c.headGetter,
 			HashMaker:  &c.hashMaker,
 		})
@@ -467,7 +466,6 @@ func TestDownload(t *testing.T) {
 		}
 	}
 }
-
 
 func TestGetMultiPartSize(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
# やったこと

golangci-lintを導入して、これまでpushしたファイルを検査してみた。
設定ファイルは、golangci-lintから拝借し、不要そうなところをコメントアウトした。
実施したところ以下のような出力となった。
#は私のコメント。

```
$ golangci-lint run s3/s3.go
# 名前付き戻り値を指定して、returnのみを行っているとき、関数の行数が多すぎると指摘されるよう。
# 遅延処理内でerrorがあった時はerror戻り値としたいので、名前付き戻り値はそのままにして、単にreturnの時に返す値を指定するようにした。
s3/s3.go:178:2: naked return in func `upload` with 33 lines of code (nakedret)
	return
	^
# goimportsの出力をそのまま使うことにした。
s3/s3.go:7: File is not `goimports`-ed with -local github.com/golangci/golangci-lint (goimports)
	"github.com/aws/aws-sdk-go/aws"
	"github.com/aws/aws-sdk-go/aws/credentials"
	"github.com/aws/aws-sdk-go/aws/session"
	client "github.com/aws/aws-sdk-go/service/s3"
	manager "github.com/aws/aws-sdk-go/service/s3/s3manager"
# 処理上md5が必要だったので、nolintとして、指摘を抑制した
s3/s3.go:4: G501: Blacklisted import `crypto/md5`: weak cryptographic primitive (gosec)
	"crypto/md5"
s3/s3.go:350: G401: Use of weak cryptographic primitive (gosec)
		sum := md5.Sum(b[:n])
s3/s3.go:353: G401: Use of weak cryptographic primitive (gosec)
	sum := md5.Sum(h)
s3/s3.go:370: G401: Use of weak cryptographic primitive (gosec)
	h := md5.New()
# プロパティ名を変更した。
s3/s3.go:53:2: struct field `Id` should be `ID` (golint)
	Id         string
	^
# テストコードのDIに必要な構造体だったので、_にせずに名前を与えた。
s3/s3.go:146:1: receiver name should not be an underscore, omit the name if it is unused (golint)
func (_ *Uploader) upload(s3 *S3, filePath, s3Path string) (out *manager.UploadOutput, err error) {
^
s3/s3.go:212:1: receiver name should not be an underscore, omit the name if it is unused (golint)
func (_ Downloader) download(s3 *S3, filePath, s3Path string) (n int64, err error) {
^
s3/s3.go:240:1: receiver name should not be an underscore, omit the name if it is unused (golint)
func (_ *HeadGetter) get(s3 *S3, s3Path string) (out *client.HeadObjectOutput, err error) {
^
# 指摘どおりにした。
s3/s3.go:319:3: should replace `d += 1` with `d++` (golint)
		d += 1
		^
# 指摘どおりにlen(eTag) == 0としたところ、さらにeTag == ""にしろと言われたのでそのとおりにした。
s3/s3.go:294:5: sloppyLen: len(eTag) <= 0 can be len(eTag) == 0 (gocritic)
	if len(eTag) <= 0 {
	   ^
# waitDurationに変更した。
s3/s3.go:45:2: ST1011: var waitSec is of type time.Duration; don't use unit-specific suffix "Sec" (stylecheck)
	waitSec     time.Duration
	^
s3/s3.go:59:2: ST1011: var WaitSec is of type time.Duration; don't use unit-specific suffix "Sec" (stylecheck)
	WaitSec    time.Duration
	^

```

```
$ golangci-lint run s3/s3_test.go s3/s3.go
# テストコードの関数の行数が多すぎると指摘されたが、対処する必要は無いと思いnolintとした。
s3/s3_test.go:71: Function 'TestUpload' is too long (187 > 100) (funlen)
func TestUpload(t *testing.T) {
s3/s3_test.go:279: Function 'TestDownload' is too long (187 > 100) (funlen)
func TestDownload(t *testing.T) {
# テストコードのリテラルを定数にできると指摘されたが、対処する必要は無いと思いnolintとした。
s3/s3_test.go:73:10: string `  \1234567890\"  "` has 2 occurrences, make it a constant (goconst)
	eTag := "  \"1234567890\"  "
	        ^
```
